### PR TITLE
Ml exclude rails dom testing from rails

### DIFF
--- a/exe/bundle_report
+++ b/exe/bundle_report
@@ -25,7 +25,7 @@ at_exit do
       options[:rails_version] = rails_version
     end
 
-    opts.on("--include-rails-gems", "Inlcude Rails gems in compatibility report (defaults to false)") do
+    opts.on("--include-rails-gems", "Include Rails gems in compatibility report (defaults to false)") do
       options[:include_rails_gems] = true
     end
 

--- a/exe/bundle_report
+++ b/exe/bundle_report
@@ -258,7 +258,6 @@ class BundleReport
         "activestorage",
         "activesupport",
         "railties",
-        "rails-dom-testing",
       ]
     end
   end


### PR DESCRIPTION
This fixes a problem where jquery-rails was reported wrongly:
```
jquery-rails 4.3.3 - new version, 4.3.3, is not compatible with Rails 5.0
```

Note that the gemspec declares: `s.add_dependency "rails-dom-testing", ">= 1", "< 3"`
https://github.com/rails/jquery-rails/blob/bfaaa31752c74215a80e7100b35c37b889adbd39/jquery-rails.gemspec#L21

Internally, this led to a comparison like this (pseudo-code):
`[< 3, >= 1].satisfied_by?(5.0)`


