### PR TITLE
Add required_ruby_version and description to the gem's configuration

### DIFF
--- a/ten_years_rails.gemspec
+++ b/ten_years_rails.gemspec
@@ -10,8 +10,11 @@ Gem::Specification.new do |spec|
   spec.email         = ["jnraine@gmail.com"]
 
   spec.summary       = %q{Companion code to Ten Years of Rails Upgrades}
+  spec.description   = %q{A set of handy tools to upgrade your Rails application and keep it up to date}
   spec.homepage      = "https://github.com/clio/ten_years_rails"
   spec.license       = "MIT"
+
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
Hey @jnraine, 

I believe this PR improves the configuration based on what we discussed in https://github.com/clio/ten_years_rails/issues/9

It's not the best solution, but it should provide more info for anyone trying to use this gem with Ruby < 2.3

Please check it out.

Thanks!