### PR TITLE
Fixes/ruby 2 2 syntax error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.2.10
   - 2.3.3
 before_install: gem install bundler -v 1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     ten_years_rails (0.2.0)
       actionview
-      activesupport
       colorize (>= 0.8.1)
       rest-client (>= 2.0.2)
 
@@ -31,7 +30,7 @@ GEM
     erubi (1.8.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.6.0)
+    i18n (1.5.1)
       concurrent-ruby (~> 1.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
@@ -42,7 +41,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     netrc (0.11.0)
-    nokogiri (1.10.2)
+    nokogiri (1.9.1)
       mini_portile2 (~> 2.4.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
@@ -72,7 +71,7 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
 
 PLATFORMS
   ruby

--- a/exe/bundle_report
+++ b/exe/bundle_report
@@ -64,7 +64,10 @@ require "json"
 require "rest-client"
 
 class BundleReport
-  def self.compatibility(rails_version:, include_rails_gems:)
+  def self.compatibility(opts = {})
+    rails_version = opts[:rails_version]
+    include_rails_gems = opts[:include_rails_gems]
+
     incompatible_gems = BundleReport::GemInfo.all.reject do |gem|
       gem.compatible_with_rails?(rails_version: rails_version) || (!include_rails_gems && gem.from_rails?)
     end.sort_by do |gem|
@@ -229,11 +232,13 @@ class BundleReport
       end
     end
 
-    def compatible_with_rails?(rails_version: Gem::Version.new("5.0"))
+    def compatible_with_rails?(opts = {})
+      rails_version = opts[:rails_version] || Gem::Version.new("5.0")
       unsatisfied_rails_dependencies(rails_version: rails_version).empty?
     end
 
-    def unsatisfied_rails_dependencies(rails_version:)
+    def unsatisfied_rails_dependencies(opts = {})
+      rails_version = opts[:rails_version]
       rails_dependencies = gem_specification.runtime_dependencies.select {|dependency| rails_gems.include?(dependency.name) }
 
       rails_dependencies.reject do |rails_dependency|

--- a/exe/bundle_report
+++ b/exe/bundle_report
@@ -8,7 +8,7 @@ at_exit do
 
   options = {}
   option_parser = OptionParser.new do |opts|
-    opts.banner = <<~EOS
+    opts.banner = <<-EOS
       Usage: #{$0} [report-type] [options]
 
       report-type  There are two report types available: `outdated` and `compatibility`
@@ -76,7 +76,7 @@ class BundleReport
 
     incompatible_gems_by_state = incompatible_gems.group_by { |gem| gem.state(rails_version) }
 
-    template = <<~ERB
+    template = <<-ERB
       <% if incompatible_gems_by_state[:latest_compatible] -%>
       <%= "=> Incompatible with Rails #{rails_version} (with new versions that are compatible):".white.bold %>
       <%= "These gems will need to be upgraded before upgrading to Rails #{rails_version}.".italic %>
@@ -126,13 +126,13 @@ class BundleReport
     out_of_date_gems.each do |_gem|
       header = "#{_gem.name} #{_gem.version}"
 
-      puts <<~MESSAGE
+      puts <<-MESSAGE
         #{header.bold.white}: released #{_gem.age} (latest version, #{_gem.latest_version.version}, released #{_gem.latest_version.age})
       MESSAGE
     end
 
     puts ""
-    puts <<~MESSAGE
+    puts <<-MESSAGE
       #{"#{sourced_from_git.count}".yellow} gems are sourced from git
       #{"#{out_of_date_gems.length}".red} of the #{gems.count} gems are out-of-date (#{percentage_out_of_date}%)
     MESSAGE

--- a/exe/bundle_report
+++ b/exe/bundle_report
@@ -245,7 +245,9 @@ class BundleReport
       rails_gems.include?(name)
     end
 
-    private def rails_gems
+    private
+
+    def rails_gems
       [
         "rails",
         "activemodel",

--- a/exe/bundle_report
+++ b/exe/bundle_report
@@ -77,35 +77,35 @@ class BundleReport
     incompatible_gems_by_state = incompatible_gems.group_by { |gem| gem.state(rails_version) }
 
     template = <<-ERB
-      <% if incompatible_gems_by_state[:latest_compatible] -%>
-      <%= "=> Incompatible with Rails #{rails_version} (with new versions that are compatible):".white.bold %>
-      <%= "These gems will need to be upgraded before upgrading to Rails #{rails_version}.".italic %>
+<% if incompatible_gems_by_state[:latest_compatible] -%>
+<%= "=> Incompatible with Rails #{rails_version} (with new versions that are compatible):".white.bold %>
+<%= "These gems will need to be upgraded before upgrading to Rails #{rails_version}.".italic %>
 
-      <% incompatible_gems_by_state[:latest_compatible].each do |gem| -%>
-      <%= gem_header(gem) %> - upgrade to <%= gem.latest_version.version %>
-      <% end -%>
+<% incompatible_gems_by_state[:latest_compatible].each do |gem| -%>
+<%= gem_header(gem) %> - upgrade to <%= gem.latest_version.version %>
+<% end -%>
 
-      <% end -%>
-      <% if incompatible_gems_by_state[:incompatible] -%>
-      <%= "=> Incompatible with Rails #{rails_version} (with no new compatible versions):".white.bold %>
-      <%= "These gems will need to be removed or replaced before upgrading to Rails #{rails_version}.".italic %>
+<% end -%>
+<% if incompatible_gems_by_state[:incompatible] -%>
+<%= "=> Incompatible with Rails #{rails_version} (with no new compatible versions):".white.bold %>
+<%= "These gems will need to be removed or replaced before upgrading to Rails #{rails_version}.".italic %>
 
-      <% incompatible_gems_by_state[:incompatible].each do |gem| -%>
-      <%= gem_header(gem) %> - new version, <%= gem.latest_version.version %>, is not compatible with Rails #{rails_version}
-      <% end -%>
+<% incompatible_gems_by_state[:incompatible].each do |gem| -%>
+<%= gem_header(gem) %> - new version, <%= gem.latest_version.version %>, is not compatible with Rails #{rails_version}
+<% end -%>
 
-      <% end -%>
-      <% if incompatible_gems_by_state[:no_new_version] -%>
-      <%= "=> Incompatible with Rails #{rails_version} (with no new versions):".white.bold %>
-      <%= "These gems will need to be upgraded by us or removed before upgrading to Rails #{rails_version}.".italic %>
-      <%= "This list is likely to contain internal gems, like Cuddlefish.".italic %>
+<% end -%>
+<% if incompatible_gems_by_state[:no_new_version] -%>
+<%= "=> Incompatible with Rails #{rails_version} (with no new versions):".white.bold %>
+<%= "These gems will need to be upgraded by us or removed before upgrading to Rails #{rails_version}.".italic %>
+<%= "This list is likely to contain internal gems, like Cuddlefish.".italic %>
 
-      <% incompatible_gems_by_state[:no_new_version].each do |gem| -%>
-      <%= gem_header(gem) %> - new version not found
-      <% end -%>
+<% incompatible_gems_by_state[:no_new_version].each do |gem| -%>
+<%= gem_header(gem) %> - new version not found
+<% end -%>
 
-      <% end -%>
-      <%= incompatible_gems.length.to_s.red %> gems incompatible with Rails <%= rails_version %>
+<% end -%>
+<%= incompatible_gems.length.to_s.red %> gems incompatible with Rails <%= rails_version %>
     ERB
 
     puts ERB.new(template, nil, "-").result(binding)
@@ -127,14 +127,14 @@ class BundleReport
       header = "#{_gem.name} #{_gem.version}"
 
       puts <<-MESSAGE
-        #{header.bold.white}: released #{_gem.age} (latest version, #{_gem.latest_version.version}, released #{_gem.latest_version.age})
+#{header.bold.white}: released #{_gem.age} (latest version, #{_gem.latest_version.version}, released #{_gem.latest_version.age})
       MESSAGE
     end
 
     puts ""
     puts <<-MESSAGE
-      #{"#{sourced_from_git.count}".yellow} gems are sourced from git
-      #{"#{out_of_date_gems.length}".red} of the #{gems.count} gems are out-of-date (#{percentage_out_of_date}%)
+#{"#{sourced_from_git.count}".yellow} gems are sourced from git
+#{"#{out_of_date_gems.length}".red} of the #{gems.count} gems are out-of-date (#{percentage_out_of_date}%)
     MESSAGE
   end
 

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -4,7 +4,9 @@ require "colorize"
 require "optparse"
 require "set"
 
-def run_tests(deprecation_warnings, tracker_mode:, next_mode:)
+def run_tests(deprecation_warnings, opts = {})
+  tracker_mode = opts[:tracker_mode]
+  next_mode = opts[:next_mode]
   rspec_command = if next_mode
     "bin/next rspec"
   else
@@ -16,7 +18,8 @@ def run_tests(deprecation_warnings, tracker_mode:, next_mode:)
   exec command
 end
 
-def print_info(deprecation_warnings, verbose: false)
+def print_info(deprecation_warnings, opts = {})
+  verbose = !!opts[:verbose]
   frequency_by_message = deprecation_warnings.each_with_object({}) do |(test_file, messages), hash|
     messages.each do |message|
       hash[message] ||= { test_files: Set.new, occurrences: 0 }

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -36,7 +36,7 @@ end
 
 options = {}
 option_parser = OptionParser.new do |opts|
-  opts.banner = <<~MESSAGE
+  opts.banner = <<-MESSAGE
     Usage: #{__FILE__.to_s} [options] [mode]
 
       Parses the deprecation warning shitlist and show info or run tests.

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -39,7 +39,10 @@ class DeprecationTracker
     end
   end
 
-  def self.track_rspec(rspec_config, shitlist_path:, mode:, transform_message: nil)
+  def self.track_rspec(rspec_config, opts = {})
+    shitlist_path = opts[:shitlist_path]
+    mode = opts[:mode]
+    transform_message = opts[:transform_message]
     deprecation_tracker = DeprecationTracker.new(shitlist_path, transform_message)
     if defined?(ActiveSupport)
       ActiveSupport::Deprecation.behavior << -> (message, _callstack) { deprecation_tracker.add(message) }

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -29,11 +29,21 @@ class DeprecationTracker
 
   # There are two forms of the `warn` method: one for class Kernel and one for instances of Kernel (i.e., every Object)
   Object.prepend(KernelWarnTracker)
-  Kernel.singleton_class.prepend(KernelWarnTracker)
+
+  # Ruby 2.2 and lower doesn't appear to allow overriding of Kernel.warn using `singleton_class.prepend`.
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.3.0")
+    Kernel.singleton_class.prepend(KernelWarnTracker)
+  else
+    def Kernel.warn(*args, &block)
+      Object.warn(*args, &block)
+    end
+  end
 
   def self.track_rspec(rspec_config, shitlist_path:, mode:, transform_message: nil)
     deprecation_tracker = DeprecationTracker.new(shitlist_path, transform_message)
-    ActiveSupport::Deprecation.behavior << -> (message, _callstack) { deprecation_tracker.add(message) }
+    if defined?(ActiveSupport)
+      ActiveSupport::Deprecation.behavior << -> (message, _callstack) { deprecation_tracker.add(message) }
+    end
     KernelWarnTracker.callbacks << -> (message) { deprecation_tracker.add(message) }
 
     rspec_config.around do |example|

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -86,7 +86,7 @@ class DeprecationTracker
     end
 
     if changed_buckets.length > 0
-      message = <<~MESSAGE.red
+      message = <<-MESSAGE.red
         ⚠️  Deprecation warnings have changed!
 
         Code called by the following spec files is now generating different deprecation warnings:
@@ -119,7 +119,7 @@ class DeprecationTracker
     new_shitlist = create_temp_shitlist
     FileUtils.cp(new_shitlist.path, shitlist_path)
   ensure
-    new_shitlist&.delete
+    new_shitlist.delete if new_shitlist
   end
 
   def create_temp_shitlist

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -4,7 +4,7 @@ require_relative "../lib/deprecation_tracker"
 
 RSpec.describe DeprecationTracker do
   let(:shitlist_path) do
-    shitlist_path = Tempfile.new.path
+    shitlist_path = Tempfile.new("tmp").path
     FileUtils.rm(shitlist_path)
     shitlist_path
   end
@@ -92,14 +92,14 @@ RSpec.describe DeprecationTracker do
 
       subject.save
 
-      expected_json = <<~JSON.chomp
-        {
-          "bucket 1": [
-            "a",
-            "b",
-            "b"
-          ]
-        }
+      expected_json = <<-JSON.chomp
+{
+  "bucket 1": [
+    "a",
+    "b",
+    "b"
+  ]
+}
       JSON
       expect(File.read(shitlist_path)).to eq(expected_json)
     end
@@ -116,15 +116,15 @@ RSpec.describe DeprecationTracker do
       subject.add("a")
       subject.save
 
-      expected_json = <<~JSON.chomp
-        {
-          "bucket 1": [
-            "a"
-          ],
-          "bucket 2": [
-            "a"
-          ]
-        }
+      expected_json = <<-JSON.chomp
+{
+  "bucket 1": [
+    "a"
+  ],
+  "bucket 2": [
+    "a"
+  ]
+}
       JSON
       expect(File.read(shitlist_path)).to eq(expected_json)
     end
@@ -141,12 +141,12 @@ RSpec.describe DeprecationTracker do
       subject.add("b")
       subject.save
 
-      expected_json = <<~JSON.chomp
-        {
-          "bucket 1": [
-            "b"
-          ]
-        }
+      expected_json = <<-JSON.chomp
+{
+  "bucket 1": [
+    "b"
+  ]
+}
       JSON
       expect(File.read(shitlist_path)).to eq(expected_json)
     end
@@ -159,15 +159,15 @@ RSpec.describe DeprecationTracker do
       subject.add("a")
       subject.save
 
-      expected_json = <<~JSON.chomp
-        {
-          "bucket 1": [
-            "a"
-          ],
-          "bucket 2": [
-            "a"
-          ]
-        }
+      expected_json = <<-JSON.chomp
+{
+  "bucket 1": [
+    "a"
+  ],
+  "bucket 2": [
+    "a"
+  ]
+}
       JSON
       expect(File.read(shitlist_path)).to eq(expected_json)
     end
@@ -180,14 +180,14 @@ RSpec.describe DeprecationTracker do
       subject.add("a")
       subject.save
 
-      expected_json = <<~JSON.chomp
-        {
-          "bucket 1": [
-            "a",
-            "b",
-            "c"
-          ]
-        }
+      expected_json = <<-JSON.chomp
+{
+  "bucket 1": [
+    "a",
+    "b",
+    "c"
+  ]
+}
       JSON
       expect(File.read(shitlist_path)).to eq(expected_json)
     end

--- a/ten_years_rails.gemspec
+++ b/ten_years_rails.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "actionview"
-  spec.add_dependency "activesupport"
   spec.add_dependency "colorize", ">= 0.8.1"
   spec.add_dependency "rest-client", ">= 2.0.2"
   spec.add_development_dependency "bundler", "~> 1.16"


### PR DESCRIPTION
Hey @jnraine, 

This is an attempt to fix #13. Unfortunately it seems that it will generate a spec failure: 

```
$ bundle exec rspec spec

DeprecationTracker
  #add
    groups messages by bucket
    ignores messages when bucket null
    transforms messages before adding them
  #compare
    ignores buckets that have no messages
    raises an error when recorded messages are different for a given bucket
  #save
    saves to disk
    combines recorded and stored messages
    overwrites stored messages with recorded messages with the same bucket
    sorts by bucket
    sorts messages
  DeprecationTracker::KernelWarnTracker
    captures Kernel#warn (FAILED - 1)
    captures Kernel.warn (FAILED - 2)

TenYearsRails
  has a version number

Failures:

  1) DeprecationTracker DeprecationTracker::KernelWarnTracker captures Kernel#warn
     Failure/Error: expect(warn_messages).to eq(["oh", "no"])

       expected: ["oh", "no"]
            got: []

       (compared using ==)
     # ./spec/deprecation_tracker_spec.rb:206:in `block (3 levels) in <top (required)>'

  2) DeprecationTracker DeprecationTracker::KernelWarnTracker captures Kernel.warn
     Failure/Error: expect(warn_messages).to eq(["oh", "no"])

       expected: ["oh", "no"]
            got: []

       (compared using ==)
     # ./spec/deprecation_tracker_spec.rb:218:in `block (3 levels) in <top (required)>'

Finished in 0.04994 seconds (files took 0.24047 seconds to load)
13 examples, 2 failures

Failed examples:

rspec ./spec/deprecation_tracker_spec.rb:197 # DeprecationTracker DeprecationTracker::KernelWarnTracker captures Kernel#warn
rspec ./spec/deprecation_tracker_spec.rb:209 # DeprecationTracker DeprecationTracker::KernelWarnTracker captures Kernel.warn
```

I'm not sure what's the best way to fix that issue. It's probably related to dropping `activesupport` as a dependency. Any thoughts about that?

Thanks!