### PR TITLE
Backport upstream changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-# Specify your gem's dependencies in next_rails.gemspec
+# Specify your gem's dependencies in ten_years_rails.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: .
   specs:
-    ten_years_rails (1.0.0)
-      actionview
+    ten_years_rails (1.0.1)
+      actionview (~> 5.2.3)
       colorize (>= 0.8.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionview (5.2.3)
-      activesupport (= 5.2.3)
+    actionview (5.2.4)
+      activesupport (= 5.2.4)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activesupport (5.2.3)
+    activesupport (5.2.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -24,21 +24,21 @@ GEM
     concurrent-ruby (1.1.5)
     crass (1.0.5)
     diff-lcs (1.3)
-    erubi (1.8.0)
-    i18n (1.6.0)
+    erubi (1.9.0)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    loofah (2.3.1)
+    loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
-    nokogiri (1.10.5)
+    minitest (5.13.0)
+    nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.4)
-      loofah (~> 2.2, >= 2.2.2)
+    rails-html-sanitizer (1.3.0)
+      loofah (~> 2.3)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -63,9 +63,9 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
-  ten_years_rails!
   rake (~> 10.0)
   rspec (~> 3.0)
+  ten_years_rails!
   timecop (~> 0.9.1)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    next_rails (1.0.0)
+    ten_years_rails (1.0.0)
       actionview
       colorize (>= 0.8.1)
 
@@ -63,7 +63,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
-  next_rails!
+  ten_years_rails!
   rake (~> 10.0)
   rspec (~> 3.0)
   timecop (~> 0.9.1)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ next rails s        # Start server using Gemfile.next
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'next_rails'
+gem 'ten_years_rails'
 ```
 
 And then execute:
@@ -89,7 +89,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install next_rails
+    $ gem install ten_years_rails
 
 ## License
 

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "next_rails"
+require "ten_years_rails"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/exe/bundle_report
+++ b/exe/bundle_report
@@ -5,7 +5,7 @@
 #
 at_exit do
   require "optparse"
-  require "next_rails"
+  require "ten_years_rails"
 
   options = {}
   option_parser = OptionParser.new do |opts|
@@ -47,9 +47,9 @@ at_exit do
   report_type = ARGV.first
 
   case report_type
-  when "outdated" then NextRails::BundleReport.outdated
+  when "outdated" then TenYearsRails::BundleReport.outdated
   else
-    NextRails::BundleReport.compatibility(rails_version: options.fetch(:rails_version, "5.0"), include_rails_gems: options.fetch(:include_rails_gems, false))
+    TenYearsRails::BundleReport.compatibility(rails_version: options.fetch(:rails_version, "5.0"), include_rails_gems: options.fetch(:include_rails_gems, false))
   end
 end
 

--- a/lib/next_rails.rb
+++ b/lib/next_rails.rb
@@ -1,8 +1,0 @@
-require "next_rails/gem_info"
-require "next_rails/version"
-require "next_rails/bundle_report"
-require "deprecation_tracker"
-
-module NextRails
-  # Your code goes here...
-end

--- a/lib/ten_years_rails.rb
+++ b/lib/ten_years_rails.rb
@@ -1,0 +1,8 @@
+require "ten_years_rails/gem_info"
+require "ten_years_rails/version"
+require "ten_years_rails/bundle_report"
+require "deprecation_tracker"
+
+module TenYearsRails
+  # Your code goes here...
+end

--- a/lib/ten_years_rails/bundle_report.rb
+++ b/lib/ten_years_rails/bundle_report.rb
@@ -3,10 +3,10 @@ require "cgi"
 require "erb"
 require "json"
 
-module NextRails
+module TenYearsRails
   class BundleReport
     def self.compatibility(rails_version:, include_rails_gems:)
-      incompatible_gems = NextRails::GemInfo.all.reject do |gem|
+      incompatible_gems = TenYearsRails::GemInfo.all.reject do |gem|
         gem.compatible_with_rails?(rails_version: rails_version) || (!include_rails_gems && gem.from_rails?)
       end.sort_by do |gem|
         [
@@ -59,7 +59,7 @@ module NextRails
     end
 
     def self.outdated
-      gems = NextRails::GemInfo.all
+      gems = TenYearsRails::GemInfo.all
       out_of_date_gems = gems.reject(&:up_to_date?).sort_by(&:created_at)
       percentage_out_of_date = ((out_of_date_gems.count / gems.count.to_f) * 100).round
       sourced_from_git = gems.select(&:sourced_from_git?)

--- a/lib/ten_years_rails/gem_info.rb
+++ b/lib/ten_years_rails/gem_info.rb
@@ -4,7 +4,7 @@ rescue LoadError
   puts "ActionView not available"
 end
 
-module NextRails
+module TenYearsRails
   class GemInfo
     if defined?(ActionView)
       include ActionView::Helpers::DateHelper

--- a/lib/ten_years_rails/version.rb
+++ b/lib/ten_years_rails/version.rb
@@ -1,3 +1,3 @@
-module NextRails
+module TenYearsRails
   VERSION = "1.0.1"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "next_rails"
+require "ten_years_rails"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/ten_years_rails/gem_info_spec.rb
+++ b/spec/ten_years_rails/gem_info_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "timecop"
 
-RSpec.describe NextRails::GemInfo do
+RSpec.describe TenYearsRails::GemInfo do
   let(:release_date) { Time.utc(2019, 7, 6, 0, 0, 0) }
   let(:now) { Time.utc(2019, 7, 6, 12, 0, 0) }
   let(:spec) do
@@ -10,7 +10,7 @@ RSpec.describe NextRails::GemInfo do
     end
   end
 
-  subject { NextRails::GemInfo.new(spec) }
+  subject { TenYearsRails::GemInfo.new(spec) }
 
   describe "#age" do
     around do |example|

--- a/spec/ten_years_rails_spec.rb
+++ b/spec/ten_years_rails_spec.rb
@@ -1,5 +1,5 @@
-RSpec.describe NextRails do
+RSpec.describe TenYearsRails do
   it "has a version number" do
-    expect(NextRails::VERSION).not_to be nil
+    expect(TenYearsRails::VERSION).not_to be nil
   end
 end

--- a/ten_years_rails.gemspec
+++ b/ten_years_rails.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "timecop", "~> 0.9.1"
-  spec.add_runtime_dependency "actionview"
+  spec.add_runtime_dependency "actionview", "~> 5.2.3"
 end

--- a/ten_years_rails.gemspec
+++ b/ten_years_rails.gemspec
@@ -1,17 +1,17 @@
 
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "next_rails/version"
+require "ten_years_rails/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "next_rails"
-  spec.version       = NextRails::VERSION
+  spec.name          = "ten_years_rails"
+  spec.version       = TenYearsRails::VERSION
   spec.authors       = ["Jordan Raine", "Ernesto Tagwerker"]
   spec.email         = ["jnraine@gmail.com", "ernesto@ombulabs.com"]
 
   spec.summary       = %q{Companion code to Ten Years of Rails Upgrades}
   spec.description   = %q{A set of handy tools to upgrade your Rails application and keep it up to date}
-  spec.homepage      = "https://github.com/fastruby/next_rails"
+  spec.homepage      = "https://github.com/clio/ten_years_rails"
   spec.license       = "MIT"
 
   spec.required_ruby_version = ">= 2.3.0"


### PR DESCRIPTION
This PR merges all the upstream changes from [next_rails/master](https://github.com/fastruby/next_rails). Thanks @etagwerker for all your great work on the gem! 🎉 

Among other things, this addresses the changes proposed in #14 and #17.

References to `next_rails`/`NextRails` have been adjusted to `ten_years_rails`/`TenYearsRails` to keep things consistent with this gem's name.