### PR TITLE
🌈 Replace colorize with rainbow

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ten_years_rails (1.0.1)
       actionview (~> 5.2.3)
-      colorize (>= 0.8.1)
+      rainbow (~> 3.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -20,7 +20,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     builder (3.2.3)
-    colorize (0.8.1)
     concurrent-ruby (1.1.5)
     crass (1.0.5)
     diff-lcs (1.3)
@@ -39,6 +38,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rainbow (3.0.0)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)

--- a/exe/bundle_report
+++ b/exe/bundle_report
@@ -39,7 +39,7 @@ at_exit do
   begin
     option_parser.parse!
   rescue OptionParser::ParseError => e
-    STDERR.puts e.message.red
+    STDERR.puts Rainbow(e.message).red
     puts option_parser
     exit 1
   end

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require "json"
-require "colorize"
+require "rainbow"
 require "optparse"
 require "set"
 
@@ -30,9 +30,9 @@ def print_info(deprecation_warnings, opts = {})
 
   puts "Ten most common deprecation warnings:".underline
   frequency_by_message.take(10).each do |message, data|
-    puts "Occurrences: #{data.fetch(:occurrences)}".bold
+    puts Rainbow("Occurrences: #{data.fetch(:occurrences)}").bold
     puts "Test files: #{data.fetch(:test_files).to_a.join(" ")}" if verbose
-    puts message.red
+    puts Rainbow(message).red
     puts "----------"
   end
 end
@@ -104,10 +104,10 @@ case options.fetch(:mode, "info")
 when "run" then run_tests(deprecation_warnings, next_mode: options[:next], tracker_mode: options[:tracker_mode])
 when "info" then print_info(deprecation_warnings, verbose: options[:verbose])
 when nil
-  STDERR.puts "Must pass a mode: run or info".red
+  STDERR.puts Rainbow("Must pass a mode: run or info").red
   puts option_parser
   exit 1
 else
-  STDERR.puts "Unknown mode: #{options[:mode]}".red
+  STDERR.puts Rainbow("Unknown mode: #{options[:mode]}").red
   exit 1
 end

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -1,4 +1,4 @@
-require "colorize"
+require "rainbow"
 require "json"
 
 # A shitlist for deprecation warnings during test runs. It has two modes: "save" and "compare"
@@ -99,7 +99,7 @@ class DeprecationTracker
     end
 
     if changed_buckets.length > 0
-      message = <<-MESSAGE.red
+      message = Rainbow(<<-MESSAGE).red
         ⚠️  Deprecation warnings have changed!
 
         Code called by the following spec files is now generating different deprecation warnings:

--- a/lib/ten_years_rails/bundle_report.rb
+++ b/lib/ten_years_rails/bundle_report.rb
@@ -1,4 +1,4 @@
-require "colorize"
+require "rainbow"
 require "cgi"
 require "erb"
 require "json"
@@ -19,8 +19,8 @@ module TenYearsRails
 
       template = <<~ERB
         <% if incompatible_gems_by_state[:latest_compatible] -%>
-        <%= "=> Incompatible with Rails #{rails_version} (with new versions that are compatible):".white.bold %>
-        <%= "These gems will need to be upgraded before upgrading to Rails #{rails_version}.".italic %>
+        <%= Rainbow("=> Incompatible with Rails #{rails_version} (with new versions that are compatible):").white.bold %>
+        <%= Rainbow("These gems will need to be upgraded before upgrading to Rails #{rails_version}.").italic %>
 
         <% incompatible_gems_by_state[:latest_compatible].each do |gem| -%>
         <%= gem_header(gem) %> - upgrade to <%= gem.latest_version.version %>
@@ -28,8 +28,8 @@ module TenYearsRails
 
         <% end -%>
         <% if incompatible_gems_by_state[:incompatible] -%>
-        <%= "=> Incompatible with Rails #{rails_version} (with no new compatible versions):".white.bold %>
-        <%= "These gems will need to be removed or replaced before upgrading to Rails #{rails_version}.".italic %>
+        <%= Rainbow("=> Incompatible with Rails #{rails_version} (with no new compatible versions):").white.bold %>
+        <%= Rainbow("These gems will need to be removed or replaced before upgrading to Rails #{rails_version}.").italic %>
 
         <% incompatible_gems_by_state[:incompatible].each do |gem| -%>
         <%= gem_header(gem) %> - new version, <%= gem.latest_version.version %>, is not compatible with Rails #{rails_version}
@@ -37,16 +37,16 @@ module TenYearsRails
 
         <% end -%>
         <% if incompatible_gems_by_state[:no_new_version] -%>
-        <%= "=> Incompatible with Rails #{rails_version} (with no new versions):".white.bold %>
-        <%= "These gems will need to be upgraded by us or removed before upgrading to Rails #{rails_version}.".italic %>
-        <%= "This list is likely to contain internal gems, like Cuddlefish.".italic %>
+        <%= Rainbow("=> Incompatible with Rails #{rails_version} (with no new versions):").white.bold %>
+        <%= Rainbow("These gems will need to be upgraded by us or removed before upgrading to Rails #{rails_version}.").italic %>
+        <%= Rainbow("This list is likely to contain internal gems, like Cuddlefish.").italic %>
 
         <% incompatible_gems_by_state[:no_new_version].each do |gem| -%>
         <%= gem_header(gem) %> - new version not found
         <% end -%>
 
         <% end -%>
-        <%= incompatible_gems.length.to_s.red %> gems incompatible with Rails <%= rails_version %>
+        <%= Rainbow(incompatible_gems.length.to_s).red %> gems incompatible with Rails <%= rails_version %>
       ERB
 
       puts ERB.new(template, nil, "-").result(binding)
@@ -68,14 +68,14 @@ module TenYearsRails
         header = "#{_gem.name} #{_gem.version}"
 
         puts <<~MESSAGE
-          #{header.bold.white}: released #{_gem.age} (latest version, #{_gem.latest_version.version}, released #{_gem.latest_version.age})
+          #{Rainbow(header).bold.white}: released #{_gem.age} (latest version, #{_gem.latest_version.version}, released #{_gem.latest_version.age})
         MESSAGE
       end
 
       puts ""
       puts <<~MESSAGE
-        #{"#{sourced_from_git.count}".yellow} gems are sourced from git
-        #{"#{out_of_date_gems.length}".red} of the #{gems.count} gems are out-of-date (#{percentage_out_of_date}%)
+        #{Rainbow(sourced_from_git.count.to_s).yellow} gems are sourced from git
+        #{Rainbow(out_of_date_gems.length.to_s).red} of the #{gems.count} gems are out-of-date (#{percentage_out_of_date}%)
       MESSAGE
     end
   end

--- a/ten_years_rails.gemspec
+++ b/ten_years_rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "colorize", ">= 0.8.1"
+  spec.add_dependency "rainbow", "~> 3.0.0"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Replaces the `colorize` gem with `rainbow`, in order to avoid the GPL 2.0 license.

`rainbow` maintains a similar interface but does not monkey-patch string, so all occurrences have been updated with the new syntax.

Fixes #19