### PR TITLE
Fixed undefined method bold for plain String

### DIFF
--- a/lib/ten_years_rails/bundle_report.rb
+++ b/lib/ten_years_rails/bundle_report.rb
@@ -53,8 +53,8 @@ module TenYearsRails
     end
 
     def self.gem_header(_gem)
-      header = "#{_gem.name} #{_gem.version}".bold
-      header << " (loaded from git)".magenta if _gem.sourced_from_git?
+      header = Rainbow("#{_gem.name} #{_gem.version}").bold
+      header << Rainbow(" (loaded from git)").magenta if _gem.sourced_from_git?
       header
     end
 


### PR DESCRIPTION
```
bundle exec bundle_report compatibility --rails-version 6.0.2
Traceback (most recent call last):
  7: from /Users/lucasv/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/ten_years_rails-1.0.1/exe/bundle_report:52:in `block in <top (required)>'
  6: from /Users/lucasv/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/ten_years_rails-1.0.1/lib/ten_years_rails/bundle_report.rb:52:in `compatibility'
  5: from /Users/lucasv/.rbenv/versions/2.5.3/lib/ruby/2.5.0/erb.rb:876:in `result'
  4: from /Users/lucasv/.rbenv/versions/2.5.3/lib/ruby/2.5.0/erb.rb:876:in `eval'
  3: from (erb):5:in `compatibility'
  2: from (erb):5:in `each'
  1: from (erb):6:in `block in compatibility'
/Users/lucasv/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/ten_years_rails-1.0.1/lib/ten_years_rails/bundle_report.rb:56:in `gem_header': undefined method `bold' for "devise 4.6.2":String (NoMethodError)
```