### PR TITLE
Fix rainbow - exe/deprecations bug

### DIFF
--- a/exe/deprecations
+++ b/exe/deprecations
@@ -28,7 +28,7 @@ def print_info(deprecation_warnings, opts = {})
     end
   end.sort_by {|message, data| data[:occurrences] }.reverse.to_h
 
-  puts "Ten most common deprecation warnings:".underline
+  puts Rainbow("Ten most common deprecation warnings:").underline
   frequency_by_message.take(10).each do |message, data|
     puts Rainbow("Occurrences: #{data.fetch(:occurrences)}").bold
     puts "Test files: #{data.fetch(:test_files).to_a.join(" ")}" if verbose


### PR DESCRIPTION
I upgraded to 1.0.2 and tried to run deprecations and was receiving:

`.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/ten_years_rails-1.0.2/exe/deprecations:31:in `print_info': undefined method `underline' for "Ten most common deprecation warnings:":String (NoMethodError)`

I believe this wrap was just missed.