### PR TITLE
Adding overlord.yml to tier 4 repo

### DIFF
--- a/overlord.yml
+++ b/overlord.yml
@@ -1,4 +1,4 @@
 tier: 4
-team: Back End Infrastructure
+team: backend-infrastructure
 slack_name: "#team-back-end-inf"
 slack_url: https://clio.slack.com/archives/CE15MGLFR

--- a/overlord.yml
+++ b/overlord.yml
@@ -1,0 +1,4 @@
+tier: 4
+team: Back End Infrastructure
+slack_name: "#team-back-end-inf"
+slack_url: https://clio.slack.com/archives/CE15MGLFR


### PR DESCRIPTION
Doing some work to clear up undefined repos for overlord.

The purpose of this gem is to bundle together scripts that can be used by developers to help in the process of updating `rails`. It is not intended to ever actually be committed to an application. Hence why I believe it should be designated tier 4. 

I spoke with Alex Taylor regarding ownership of this repo, and he let me know that this repo is owned by Back End Infrastructure, but there is not currently an individual owner.