### PR TITLE
Adds classification to Overlord.yml

### DIFF
--- a/overlord.yml
+++ b/overlord.yml
@@ -1,4 +1,5 @@
 tier: 4
 team: backend-infrastructure
+classification: library
 slack_name: "#team-back-end-inf"
 slack_url: https://clio.slack.com/archives/CE15MGLFR


### PR DESCRIPTION

### What problem does this solve?
Repo is now able to be classified in Overlord, this will help in future repo requirement checks

### How does this solve it?
Adds a field `classification` and a corresponding value to project's `Overlord.yml`