### PR TITLE
Setup dependabot to ignore alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 0


### PR DESCRIPTION
ten years rails is a tier 4 repo, so we don't care about dependabot updates for it