### PR TITLE
Fix old dependabot references to artifactory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,13 @@
+---
 version: 2
 registries:
-  rubygems-jfrog:
+  rubygems-github:
     type: rubygems-server
-    url: https://clio.jfrog.io/clio/api/gems/product-gem-prod/
-    username: ${{secrets.ARTIFACTORY_USERNAME}}
-    password: ${{secrets.ARTIFACTORY_API_KEY}}
-
+    url: https://rubygems.pkg.github.com/clio
+    token: "${{ secrets.DEPENDABOT_GITHUB_TOKEN }}"
 updates:
-  - package-ecosystem: "bundler"
-    directory: "/"
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 0
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 0


### PR DESCRIPTION

We are pointing at artifactory for our ruby gems when we should be pointing at github for our packages

## How this change was made

I noticed this when making a change to the `it_melted_dashboard` and saw that PRs were failing to be generated by dependabot. Using github's search, I [used this query](https://github.com/search?q=org%3Aclio+https%3A%2F%2Fclio.jfrog.io%2Fclio%2Fapi%2Fgems%2Fproduct-gem-prod%2F+path%3A.github%2Fdependabot.yml&type=code) to pull a full list of repos.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>